### PR TITLE
Add support for custom Graphite Web port

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ An Ansible role for installing [Graphite](http://graphite.wikidot.com).
 - `graphite_whisper_version` - Whisper version
 - `graphite_web_version` - Graphite Web version
 - `graphite_home` - Default directory for Graphite (default: `/opt/graphite`)
+- `graphite_web_port` - Default Apache virtual host port for Graphite Web (default: `8080`)
 - `graphite_web_secret_key` - The value of `SECRET_KEY` for Graphite Web (default: `SECRET`)
 
 ## Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,4 +5,5 @@ graphite_web_version: "0.9.12"
 
 graphite_home: "/opt/graphite"
 
+graphite_web_port: 8080
 graphite_web_secret_key: "SECRET"

--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -18,7 +18,7 @@ end
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ubuntu/trusty64"
 
-  config.vm.network "forwarded_port", guest: 80, host: 8080
+  config.vm.network "forwarded_port", guest: 8080, host: 8080
 
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "site.yml"

--- a/templates/apache/graphite.conf.j2
+++ b/templates/apache/graphite.conf.j2
@@ -1,4 +1,4 @@
-<VirtualHost *:80>
+<VirtualHost *:{{ graphite_web_port }}>
   ServerName graphite
   CustomLog /opt/graphite/storage/log/apache2/access.log combined
   ErrorLog /opt/graphite/storage/log/apache2/error.log


### PR DESCRIPTION
This changeset allows the default Apache VirtualHost port to be customized via `graphite_web_port`.
