### PR TITLE
Make Graphite component installs idempotent

### DIFF
--- a/tasks/carbon.yml
+++ b/tasks/carbon.yml
@@ -6,6 +6,7 @@
   command: "python setup.py install"
   args:
     chdir: /usr/local/src/carbon
+    creates: /opt/graphite/bin/carbon-cache.py
 
 - name: Create service account for Carbon
   user: name=carbon

--- a/tasks/graphite-web.yml
+++ b/tasks/graphite-web.yml
@@ -6,6 +6,7 @@
   shell: "python check-dependencies.py && python setup.py install"
   args:
     chdir: /usr/local/src/graphite-web
+    creates: /opt/graphite/conf/graphite.wsgi.example
 
 - name: Configure graph template colors
   copy: src=graphTemplates.conf dest={{ graphite_home }}/conf/graphTemplates.conf

--- a/tasks/whisper.yml
+++ b/tasks/whisper.yml
@@ -3,3 +3,4 @@
   command: "python setup.py install"
   args:
     chdir: /usr/local/src/whisper
+    creates: /usr/local/bin/whisper-create.py


### PR DESCRIPTION
Installations with `python setup.py install` are not idempotent by default. This changeset adds a `creates` argument to the `command` directive that executes `python setup.py install` so that it gets skipped if an installation already occurred.
