### PR TITLE
Add support for CORS

### DIFF
--- a/examples/roles.txt
+++ b/examples/roles.txt
@@ -1,7 +1,7 @@
 azavea.python,0.1.0
 azavea.pip,0.1.0
-azavea.apache2,0.1.0
+azavea.apache2,0.2.1
 azavea.git,0.1.0
 azavea.memcached,0.1.0
-azavea.collectd,0.1.0
+azavea.collectd,0.2.0
 azavea.statsite,0.1.0

--- a/tasks/graphite-web.yml
+++ b/tasks/graphite-web.yml
@@ -55,6 +55,11 @@
         group=www-data
         state=directory
 
+- name: Enable mod_headers
+  apache2_module: state=present name=headers
+  notify:
+    - Restart Apache
+
 - name: Configure Apache site for Graphite Web
   template: src=apache/graphite.conf.j2
             dest=/etc/apache2/sites-available/graphite.conf

--- a/templates/apache/graphite.conf.j2
+++ b/templates/apache/graphite.conf.j2
@@ -3,6 +3,10 @@
   CustomLog /opt/graphite/storage/log/apache2/access.log combined
   ErrorLog /opt/graphite/storage/log/apache2/error.log
 
+  Header set Access-Control-Allow-Origin "*"
+  Header set Access-Control-Allow-Methods "GET, OPTIONS"
+  Header set Access-Control-Allow-Headers "origin, authorization, accept"
+
   WSGIScriptAlias / /opt/graphite/conf/graphite.wsgi
 
   RedirectMatch ^/admin(.*)admin/([^/]+)/([^/]+)$ /media/$2/$3


### PR DESCRIPTION
This changeset adds Graphite support for CORS via changes to the Apache configuration. Methods allowed are restricted to `GET` and `OPTIONS`.