### PR TITLE
Add default retention period for Statsite

### DIFF
--- a/templates/graphite/conf/storage-schemas.conf.j2
+++ b/templates/graphite/conf/storage-schemas.conf.j2
@@ -12,6 +12,10 @@
 pattern = ^collectd\.
 retentions = 10s:1w, 60s:1y
 
+[statsite]
+pattern = ^statsite.*
+retentions = 10s:6h,1min:6d,10min:1800d
+
 [default]
 pattern = .*
 retentions = 60s:1y


### PR DESCRIPTION
This changeset introduces a default retention period for metrics that are namespaced by `statsite`.

Defaults were pulled from the StatsD [storage schemas](https://github.com/etsy/statsd/blob/master/docs/graphite.md#storage-schemas) `README` for Graphite.