### PR TITLE
Relax default retention periods for Collectd

### DIFF
--- a/templates/graphite/conf/storage-schemas.conf.j2
+++ b/templates/graphite/conf/storage-schemas.conf.j2
@@ -9,8 +9,8 @@
 # CARBON_METRIC_PREFIX and CARBON_METRIC_INTERVAL settings
 
 [collectd]
-pattern = ^collectd\.
-retentions = 10s:1w, 60s:1y
+pattern = ^collectd.*
+retentions = 10s:1d,1min:7d,10min:1y
 
 [default]
 pattern = .*


### PR DESCRIPTION
This changeset relaxes the existing retention periods for data namespaced by `collectd`.