### PR TITLE
Add support for Ansible 2.0

### DIFF
--- a/examples/roles.txt
+++ b/examples/roles.txt
@@ -1,7 +1,7 @@
 azavea.python,0.1.0
 azavea.pip,0.1.0
-azavea.apache2,0.2.2
+azavea.apache2,0.2.3
 azavea.git,0.1.0
 azavea.memcached,0.1.0
 azavea.collectd,0.2.0
-azavea.statsite,0.1.1
+azavea.statsite,1.0.0

--- a/tasks/graphite-web.yml
+++ b/tasks/graphite-web.yml
@@ -20,9 +20,13 @@
 - name: Configure Graphite Web WSGI
   template: src=graphite/conf/graphite.wsgi.j2
             dest={{ graphite_home }}/conf/graphite.wsgi
-            mode=755
+            mode=0755
   notify:
     - Restart Apache
+
+- name: Ensure that manage.py is executable
+  file: path="{{ graphite_home }}/webapp/graphite/manage.py"
+        mode=0755
 
 - name: Setup the Graphite Web database
   django_manage: command=syncdb


### PR DESCRIPTION
In this case, the `django_manage` command executes `manage.py` directly vs. as an argument to the `python` interpreter, so we need to ensure that it is executable.