### PR TITLE
Make use of YAML role specification format

### DIFF
--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -12,7 +12,7 @@ if [ "up", "provision" ].include?(ARGV.first) && File.directory?("roles") &&
   !(File.directory?("roles/azavea.memcached") || File.symlink?("roles/azavea.memcached")) ||
   !(File.directory?("roles/azavea.collectd") || File.symlink?("roles/azavea.collectd")) ||
   !(File.directory?("roles/azavea.statsite") || File.symlink?("roles/azavea.statsite"))
-  system("ansible-galaxy install --force -r roles.txt -p roles")
+  system("ansible-galaxy install --force -r roles.yml -p roles")
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|

--- a/examples/roles.txt
+++ b/examples/roles.txt
@@ -1,7 +1,0 @@
-azavea.python,0.1.0
-azavea.pip,0.1.0
-azavea.apache2,0.2.3
-azavea.git,0.1.0
-azavea.memcached,0.1.0
-azavea.collectd,0.2.0
-azavea.statsite,1.0.0

--- a/examples/roles.yml
+++ b/examples/roles.yml
@@ -1,0 +1,14 @@
+- src: azavea.python
+  version: 0.1.0
+- src: azavea.pip
+  version: 0.1.1
+- src: azavea.apache2
+  version: 0.2.3
+- src: azavea.git
+  version: 0.1.0
+- src: azavea.memcached
+  version: 0.1.0
+- src: azavea.collectd
+  version: 0.2.0
+- src: azavea.statsite
+  version: 1.1.0


### PR DESCRIPTION
The is an attempt to silence deprecation warnings in Ansible 2.0.

---

**Testing**

```bash
$ cd examples
$ rm -rf roles/azavea.apache2 roles/azavea.collectd \
    roles/azavea.git roles/azavea.memcached \
    roles/azavea.pip roles/azavea.python roles/azavea.statsite
$ vagrant destroy -f && vagrant up
```