### PR TITLE
Bump Apache role version to fix example

### DIFF
--- a/examples/roles.yml
+++ b/examples/roles.yml
@@ -3,7 +3,7 @@
 - src: azavea.pip
   version: 0.1.1
 - src: azavea.apache2
-  version: 0.2.3
+  version: 0.2.4
 - src: azavea.git
   version: 0.1.0
 - src: azavea.memcached


### PR DESCRIPTION
See also: https://github.com/azavea/ansible-apache2/pull/5

---

**Testing**

Ensure that the Vagrant project in the `examples` directory provisions correctly.
